### PR TITLE
Better scanner for the java calculator example

### DIFF
--- a/Java/Calculator/MyScanner.java
+++ b/Java/Calculator/MyScanner.java
@@ -1,33 +1,89 @@
 import java.math.*;
 import java.io.*;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MyScanner
 {
 	private ArrayStack<Object> mTokenStack;
+	private static final Rule[] RULES = {
+			new IntRule("'0|[1-9][0-9]*"),
+			new Rule("\\*\\*|[+\\-*/%()]"),
+			new SkipRule("\\s+")
+	};
 
 	public MyScanner(InputStream stream)
 	{
-		ArrayList<Object> tokenList = new ArrayList<Object>();
-		System.out.println( "Enter arithmetic expression. " + 
-							"Separate Operators with white space:");
+		System.out.println("Enter arithmetic expression:");
+
 		Scanner scanner = new Scanner(stream);
-		while (scanner.hasNext()) {
-			if (scanner.hasNextBigInteger()) {
-				tokenList.add(scanner.nextBigInteger());
-			} else {
-				tokenList.add(scanner.next());
-			}
+		StringBuilder input = new StringBuilder();
+		while (scanner.hasNextLine()) {
+			input.append(scanner.nextLine()).append('\n');
 		}
-		mTokenStack = new ArrayStack<Object>();
-		for (int i = tokenList.size() - 1; i >= 0; --i) {
-			mTokenStack.push(tokenList.get(i));
+
+		Matcher m = Pattern.compile("ignored")
+				.matcher(input)
+				.useTransparentBounds(true)
+				.useAnchoringBounds(false);
+		List<Object> tokens = new ArrayList<Object>();
+		int offset = 0;
+		final int end = input.length();
+
+		while (offset < end) {
+			m.region(offset, end);
+			for (Rule rule : RULES) {
+				if (m.usePattern(rule.pattern).lookingAt()) {
+					if (!(rule instanceof SkipRule)) {
+						tokens.add(rule.convert(input.substring(m.start(), m.end())));
+					}
+					offset = m.end() - 1;
+					break;
+				}
+			}
+			offset++;
+		}
+
+		Collections.reverse(tokens);
+		this.mTokenStack = new ArrayStack<Object>();
+		for (Object o : tokens) {
+			this.mTokenStack.push(o);
 		}
 	}
 
 	public ArrayStack<Object> getTokenStack() 
 	{
 		return mTokenStack;
+	}
+
+	private static class Rule {
+		public final Pattern pattern;
+
+		public Rule(String pattern) {
+			this.pattern = Pattern.compile(pattern);
+		}
+
+		public Object convert(String match) {
+			return match;
+		}
+	}
+
+	private static class SkipRule extends Rule {
+		private SkipRule(String pattern) {
+			super(pattern);
+		}
+	}
+
+	private static class IntRule extends Rule {
+		private IntRule(String pattern) {
+			super(pattern);
+		}
+
+		@Override
+		public Object convert(String match) {
+			return new BigInteger(match);
+		}
 	}
 }
 


### PR DESCRIPTION
I rewrote the MyScanner class to use regular expressions for the scanning just like the setlx version. The patterns were directly taken from the setlx version of the example. There are multiple slightly different copies of the scanner in the repository, I changed only the one we used for the exercise in class.
