### PR TITLE
Small refactoring

### DIFF
--- a/Python/2-3-Trees-Frame.ipynb
+++ b/Python/2-3-Trees-Frame.ipynb
@@ -1075,7 +1075,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8 Alpha 2",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/Python/2-3-Trees-Frame.ipynb
+++ b/Python/2-3-Trees-Frame.ipynb
@@ -2,22 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100%; !important } </style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#%autosave 0\n",
     "from IPython.core.display import HTML, display\n",
@@ -33,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,17 +316,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Nil()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "class Nil(TwoThreeTree):\n",
     "    def __init__(self):\n",
@@ -361,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/Python/2-3-Trees-Frame.ipynb
+++ b/Python/2-3-Trees-Frame.ipynb
@@ -2,9 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100%; !important } </style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%autosave 0\n",
     "from IPython.core.display import HTML, display\n",
@@ -20,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,24 +306,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Definition of a short function to make implementation of `__str__` methods simpler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_string(obj, type_name, attributes):\n",
+    "        # map the function __str__ to all attributes and join them with a comma\n",
+    "        return f\"{type_name}({', '.join(map(str, [getattr(obj, at) for at in attributes]))})\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The class `Nil` represents an empty tree."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nil()\n"
+     ]
+    }
+   ],
    "source": [
     "class Nil(TwoThreeTree):\n",
     "    def __init__(self):\n",
     "        TwoThreeTree.__init__(self)\n",
     "        \n",
     "    def __str__(self):\n",
-    "        return 'Nil()'\n",
+    "        return make_string(self, 'Nil', [])\n",
     "    \n",
     "    def isNil(self):\n",
-    "        return True"
+    "        return True\n"
    ]
   },
   {
@@ -322,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +376,7 @@
     "        return True\n",
     "\n",
     "    def __str__(self):\n",
-    "        return 'Two(' + str(self.mLeft) + ',' + str(self.mKey) + ',' + str(self.mRight) + ')'"
+    "        return make_string(self, 'Two', 'mLeft, mKey, mRight'.split(', '))"
    ]
   },
   {
@@ -349,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,8 +402,7 @@
     "        self.mRight  = right\n",
     "        \n",
     "    def __str__(self):\n",
-    "        return 'Three(' + str(self.mLeft) + ',' + str(self.mKeyL) + ',' + \\\n",
-    "                          str(self.mMiddle) + ',' + str(self.mKeyR) + ',' + str(self.mRight) + ')'\n",
+    "        return make_string(self, 'Three', 'mLeft, mKeyL, mMiddle, mKeyR, mRight'.split(', '))\n",
     "    \n",
     "    def isThree(self):\n",
     "        return True"
@@ -379,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,10 +433,7 @@
     "        self.mRight   = r\n",
     "        \n",
     "    def __str__(self):\n",
-    "        return 'Four(' + str(self.mLeft)    + ',' + str(self.mKeyL) + ',' + \\\n",
-    "                         str(self.mMiddleL) + ',' + str(self.mKeyM) + ',' + \\\n",
-    "                         str(self.mMiddleR) + ',' + str(self.mKeyR) + ',' + \\\n",
-    "                         str(self.mRight)   + ')'\n",
+    "        return make_string(self, 'Four', 'mLeft, mKeyL, mMiddleL, mKeyM, mMiddleR, mKeyR, mRight'.split(', '))\n",
     "    \n",
     "    def isFour(self):\n",
     "        return True"
@@ -1061,7 +1096,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8 Alpha 2",
    "language": "python",
    "name": "python3"
   },
@@ -1075,7 +1110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Makes the `__str__` methods for the classes `Nil`, `Two`, `Three` and `Four` more pythonic and shorter. 